### PR TITLE
Update index.html

### DIFF
--- a/app/states/root/children/default/index.html
+++ b/app/states/root/children/default/index.html
@@ -2,7 +2,7 @@
   Welcome to the official Angular Formly website!
   Feel free to stick around here and browse/play with the examples.
   If you want to see the docs, go to the
-  <a ng-href="{{::vm.base()}}'">angular-formly repo</a>
+  <a ng-href="{{::vm.base()}}">angular-formly repo</a>
   on GitHub.
   <div>
     <h2>Features</h2>


### PR DESCRIPTION
partial fix to broken link. Goes to https://github.com/formly-js/angular-formlyundefined' on the site. Gets rid of the ' but I don't know where the "undefined" is coming from.
