### PR TITLE
Add an example for angularjs-slider integration

### DIFF
--- a/examples.json
+++ b/examples.json
@@ -246,6 +246,13 @@
         "title": "angular-credit-card",
         "slug": "angular-credit-card",
         "jsbinId": "hijagut"
+      },
+      {
+        "title": "angularjs-slider",
+        "slug": "angularjs-slider",
+        "jsbinId": "vudameneko",
+        "keywords": "slider range-slider",
+        "noSSL": true
       }
     ]
   },


### PR DESCRIPTION
This example shows how to use a slider with Formly. It uses the angularjs-slider library.

I needed to set 2 model values for the range slider (for low and high values) but I didn't know what was the best way to do it. 

I set the model like this:

``` js
vm.model = {
    slider: 5,
    rangeSlider: {low: 2, high: 8}

}
```

and then use it like this in the type definition: `model[options.key].low` and `model[options.key].high`. Is that OK?

However, I have noticed that the `vm.options.resetModel()` function does nothing for the rangeSlider case... 
