### PR TITLE
fix: deprecated cdn for ui-bootstrap-tabs

### DIFF
--- a/examples.json
+++ b/examples.json
@@ -151,7 +151,7 @@
       {
         "title": "UI Bootstrap Tabs",
         "slug": "ui-bootstrap-tabs",
-        "jsbinId": "qadari",
+        "jsbinId": "menegexezo",
         "keywords": "angular-ui-bootstrap tabs"
       },
       {


### PR DESCRIPTION
Closes formly-js/angular-formly#609

Since v1.1.0 this is no longer valid:

```
//npmcdn.com/angular-ui-bootstrap@latest/ui-bootstrap-tpls.js
```

So I changed it to:

```
//npmcdn.com/angular-ui-bootstrap@latest/dist/ui-bootstrap-tpls.js
```
